### PR TITLE
Add SPL autoloader function

### DIFF
--- a/php-login.php
+++ b/php-login.php
@@ -37,7 +37,7 @@ function PHPLoginAutoload($classname)
         require $filename;
     } else {
         // try to load the file from the "libraries" directory
-        $filename = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'libraries' . DIRECTORY_SEPARATOR . strtolower($classname) . '.php';
+        $filename = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'libraries' . DIRECTORY_SEPARATOR . $classname . '.php';
         if (is_readable($filename)) {
             require $filename;
         // file cannot be found


### PR DESCRIPTION
Rather than include all classes that can be used by the script at the beginning of execution, I have implemented an SPL autoloader function.

This auto-loading function will be called every time a class is used but not yet loaded.
Login, Registration or PHPMailer classes are loaded only when they are really needed.

Example: The first time that "new Login();" is called, the corresponding php file is loaded.
