### PR TITLE
Add ability to disable user self-registration

### DIFF
--- a/_installation/02-create-user-table.sql
+++ b/_installation/02-create-user-table.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS `login`.`users` (
  `user_last_failed_login` int(10) DEFAULT NULL COMMENT 'unix timestamp of last failed login attempt',
  `user_registration_datetime` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
  `user_registration_ip` varchar(39) COLLATE utf8_unicode_ci NOT NULL DEFAULT '0.0.0.0',
+ `user_is_admin` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'user''s admin status',
  PRIMARY KEY (`user_id`),
  UNIQUE KEY `user_name` (`user_name`),
  UNIQUE KEY `user_email` (`user_email`)

--- a/classes/Login.php
+++ b/classes/Login.php
@@ -230,7 +230,7 @@ class Login
                 // cookie looks good, try to select corresponding user
                 if ($this->databaseConnection()) {
                     // get real token from database (and all other data)
-                    $sth = $this->db_connection->prepare("SELECT u.user_id, u.user_name, u.user_email FROM user_connections uc 
+                    $sth = $this->db_connection->prepare("SELECT u.user_id, u.user_name, u.user_email, u.user_is_admin FROM user_connections uc 
                                                           LEFT JOIN users u ON uc.user_id = u.user_id WHERE uc.user_id = :user_id
                                                           AND uc.user_rememberme_token = :user_rememberme_token AND uc.user_rememberme_token IS NOT NULL");
                     $sth->bindValue(':user_id', $user_id, PDO::PARAM_INT);
@@ -244,6 +244,7 @@ class Login
                         $_SESSION['user_id'] = $result_row->user_id;
                         $_SESSION['user_name'] = $result_row->user_name;
                         $_SESSION['user_email'] = $result_row->user_email;
+                        $_SESSION['user_is_admin'] = $result_row->user_is_admin;
                         $_SESSION['user_logged_in'] = 1;
 
                         // Cookie token usable only once
@@ -310,6 +311,7 @@ class Login
                 $_SESSION['user_id'] = $result_row->user_id;
                 $_SESSION['user_name'] = $result_row->user_name;
                 $_SESSION['user_email'] = $result_row->user_email;
+                $_SESSION['user_is_admin'] = $result_row->user_is_admin;
                 $_SESSION['user_logged_in'] = 1;
 
                 // reset the failed login counter for that user
@@ -890,6 +892,10 @@ class Login
                 $this->messages[] = MESSAGE_REGISTRATION_ACTIVATION_SUCCESSFUL;
             } else {
                 $this->errors[] = MESSAGE_REGISTRATION_ACTIVATION_NOT_SUCCESSFUL;
+
+                // check if self registration is disabled and user is not a logged in admin
+                if (!USER_ALLOW_SELF_REGISTRATION && !$_SESSION['user_is_admin'])
+                    exit(0);
             }
         }
     }

--- a/config/config.php
+++ b/config/config.php
@@ -110,3 +110,8 @@ define("EMAIL_VERIFICATION_CONTENT", "Please click on this link to activate your
  * This constant will be used in the login and the registration class.
  */
 define("HASH_COST_FACTOR", "10");
+
+/**
+ * Configuration for: user registration
+ */
+define("USER_ALLOW_SELF_REGISTRATION", true);

--- a/translations/en.php
+++ b/translations/en.php
@@ -68,6 +68,7 @@ define("WORDING_PASSWORD", "Password");
 define("WORDING_PROFILE_PICTURE", "Your profile picture (from gravatar):");
 define("WORDING_REGISTER", "Register");
 define("WORDING_REGISTER_NEW_ACCOUNT", "Register new account");
+define("WORDING_REGISTER_NEW_ACCOUNT_ADMIN", "Register new account for a user");
 define("WORDING_REGISTRATION_CAPTCHA", "Please enter these characters");
 define("WORDING_REGISTRATION_EMAIL", "User's email (please provide a real email address, you'll get a verification mail with an activation link)");
 define("WORDING_REGISTRATION_PASSWORD", "Password (min. 6 characters!)");

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -68,6 +68,7 @@ define("WORDING_PASSWORD", "Mot de passe");
 define("WORDING_PROFILE_PICTURE", "Photo de profil (depuis gravatar) :");
 define("WORDING_REGISTER", "S'enregistrer");
 define("WORDING_REGISTER_NEW_ACCOUNT", "Créer un nouveau compte");
+define("WORDING_REGISTER_NEW_ACCOUNT_ADMIN", "???Register new account for a user???");
 define("WORDING_REGISTRATION_CAPTCHA", "Saisir les caractères de l'image ci-dessus");
 define("WORDING_REGISTRATION_EMAIL", "E-mail (merci de fournir une adresse valide car vous recevrez un mail de vérification avec un lien d'activation)");
 define("WORDING_REGISTRATION_PASSWORD", "Mot de passe (min. 6 caractères)");

--- a/views/logged_in.php
+++ b/views/logged_in.php
@@ -8,4 +8,9 @@ echo WORDING_PROFILE_PICTURE . '<br/><img src="' . $login->getGravatarImageUrl()
 <div>
 	<a href="?logout"><?php echo WORDING_LOGOUT; ?></a>
 	<a href="?edit"><?php echo WORDING_EDIT_USER_DATA; ?></a>
+
+	<?php
+	if (!USER_ALLOW_SELF_REGISTRATION && $_SESSION['user_is_admin'])
+		echo "<a href=\"?register\">" . WORDING_REGISTER_NEW_ACCOUNT_ADMIN . "</a>";
+	?>
 </div>

--- a/views/login.php
+++ b/views/login.php
@@ -9,5 +9,8 @@
 	<input type="submit" name="login" value="<?php echo WORDING_LOGIN; ?>" />
 </form>
 
-<a href="?register"><?php echo WORDING_REGISTER_NEW_ACCOUNT; ?></a>
+<?php
+if (USER_ALLOW_SELF_REGISTRATION)
+	echo "<a href=\"?register\">" . WORDING_REGISTER_NEW_ACCOUNT . "</a>&nbsp;";
+?>
 <a href="?password_reset"><?php echo WORDING_FORGOT_MY_PASSWORD; ?></a>

--- a/views/register.php
+++ b/views/register.php
@@ -1,10 +1,18 @@
+<?php
+// always allow if verification_code param exists
+if (!isset($_GET["verification_code"])) {
+	// check if self registration is disabled and user is not a logged in admin
+	if (!USER_ALLOW_SELF_REGISTRATION && (!isset($_SESSION['user_is_admin']) || !$_SESSION['user_is_admin']))
+		exit(0);
+}
+?>
 
 <form method="post" action="?register">
 	<label for="user_name"><?php echo WORDING_REGISTRATION_USERNAME; ?></label>
-	<input id="user_name" type="text" pattern="[a-zA-Z0-9]{2,64}" name="user_name" value="<?php echo $_POST['user_name']; ?>" required />
+	<input id="user_name" type="text" pattern="[a-zA-Z0-9]{2,64}" name="user_name" value="<?php echo (isset($_POST['user_name']) == true ? $_POST['user_name'] : ''); ?>" required />
 
 	<label for="user_email"><?php echo WORDING_REGISTRATION_EMAIL; ?></label>
-	<input id="user_email" type="email" name="user_email" value="<?php echo $_POST['user_email']; ?>" required />
+	<input id="user_email" type="email" name="user_email" value="<?php echo (isset($_POST['user_email']) == true ? $_POST['user_email'] : ''); ?>" required />
 
 	<label for="user_password_new"><?php echo WORDING_REGISTRATION_PASSWORD; ?></label>
 	<input id="user_password_new" type="password" name="user_password_new" pattern=".{6,}" required autocomplete="off" />


### PR DESCRIPTION
Add ability to disable user self-registration with USER_ALLOW_SELF_REGISTRATION in config.php.  If USER_ALLOW_SELF_REGISTRATION is set to false, only users defined as "Admins" (via the column "user_is_admin" in "users" table) have access to register new users.
